### PR TITLE
Only allow the reveal in a future block, or the two-step process does…

### DIFF
--- a/contracts/testing/SameBlockTester.sol
+++ b/contracts/testing/SameBlockTester.sol
@@ -20,7 +20,7 @@ contract SameBlockTester {
     ctfContract = ICtf(_ctfContract);
   }
 
-  function commitAndRevealSameBlock() public payable {
+  function testCommitAndRevealSameBlock() public payable {
     string memory secret = "test";
     string memory salt = "-thesalt";
     bytes32 hash = keccak256(abi.encodePacked(secret, salt));

--- a/contracts/testing/SameBlockTester.sol
+++ b/contracts/testing/SameBlockTester.sol
@@ -1,0 +1,33 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+interface ICtf {
+  function createCtf(string memory name, bytes32 secret) external payable;
+
+  function commitAnswer(uint256 ctfId, bytes32 saltedHash) external;
+
+  function revealAnswer(
+    uint256 ctfId,
+    string memory answer,
+    string memory salt
+  ) external;
+}
+
+contract SameBlockTester {
+  ICtf private ctfContract;
+
+  constructor(address _ctfContract) {
+    ctfContract = ICtf(_ctfContract);
+  }
+
+  function commitAndRevealSameBlock() public payable {
+    string memory secret = "test";
+    string memory salt = "-thesalt";
+    bytes32 hash = keccak256(abi.encodePacked(secret, salt));
+
+    ctfContract.createCtf{ value: msg.value }("Test", hash);
+
+    ctfContract.commitAnswer(1, hash);
+    ctfContract.revealAnswer(1, secret, salt);
+  }
+}

--- a/test/ctf-v1-test.js
+++ b/test/ctf-v1-test.js
@@ -115,7 +115,7 @@ describe("CtfV1", function () {
       await testerContract.deployed();
 
       await expect(
-        testerContract.commitAndRevealSameBlock({
+        testerContract.testCommitAndRevealSameBlock({
           value: ethers.utils.parseEther("1.0"),
         })
       ).to.be.revertedWith("Can only reveal in future block");


### PR DESCRIPTION
…n’t do anything.

Added a tester contract to facilitate calling both functions in the same block. Maybe there’s a better way to do this in hardhat/jest?